### PR TITLE
filecap: do not define internal glibc symbols

### DIFF
--- a/utils/filecap.c
+++ b/utils/filecap.c
@@ -27,9 +27,7 @@
 #include <string.h>
 #include <errno.h>
 #include "cap-ng.h"
-#define __USE_GNU 1
 #include <fcntl.h>
-#define __USE_XOPEN_EXTENDED 1
 #include <ftw.h>
 
 #ifndef FTW_CONTINUE


### PR DESCRIPTION
The correct API is to define _GNU_SOURCE, not internal __xxx symbols that
glibc happens to use.  Since libcap-ng already defines that, there's no
need to redefine it.