### PR TITLE
Fix compilation without pthread.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,7 @@ AC_CHECK_HEADERS(sys/xattr.h, [], [
 	AC_CHECK_HEADERS(attr/xattr.h, [], [AC_MSG_WARN(attr/xattr.h not found, disabling file system capabilities.)])
 	])
 AC_CHECK_HEADERS(linux/securebits.h, [], [])
+AC_CHECK_HEADERS(pthread.h, [], [AC_MSG_WARN(pthread.h not found, disabling pthread_atfork.)])
 
 AC_C_CONST
 AC_C_INLINE

--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -34,7 +34,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <byteswap.h>
+#ifdef HAVE_PTHREAD_H
 #include <pthread.h>	// For pthread_atfork
+#endif
 #ifdef HAVE_SYSCALL_H
 #include <sys/syscall.h>
 #endif


### PR DESCRIPTION
Commit 7759e6f8469eb33aef1a1d5eba5d300c3a8fcb63 broke compilation on
systems without pthread.h. So add a call to AC_CHECK_HEADERS in
configure.ac and put include <pthread.h> under HAVE_PTHREAD_H define

Fixes:
 - http://autobuild.buildroot.net/results/6132f33fb282fda3c39deb292784b9006c9e7872

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>