### PR TITLE
Fix mark the DSOs as unloadable

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,5 +34,5 @@ noinst_HEADERS = captab.h
 libcap_ng_la_SOURCES = cap-ng.c lookup_table.c
 libcap_ng_la_LIBADD =
 libcap_ng_la_DEPENDENCIES = $(libcap_ng_la_SOURCES) ../config.h
-libcap_ng_la_LDFLAGS = -Wl,-z,relro
+libcap_ng_la_LDFLAGS = -Wl,-z,relro -Wl,-z,nodelete
 


### PR DESCRIPTION
as suggested by Simon McVittie in
https://github.com/stevegrubb/libcap-ng/issues/5 and Carlos O'Donell at
https://sourceware.org/bugzilla/show_bug.cgi?id=13502 mark the DSOs as
unloadable with -z nodelete to prevent crashes at fork

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=904808

Fix: https://github.com/stevegrubb/libcap-ng/issues/5