### PR TITLE
[pscap] Mark processes in child user namespaces with *.

### DIFF
--- a/utils/pscap.8
+++ b/utils/pscap.8
@@ -6,6 +6,8 @@ pscap \- a program to see capabilities
 .SH DESCRIPTION
 \fBpscap\fP is a program that prints out a report of process capabilities. If the application has any capabilities, it will be in the report with the exception of init. By giving the \-a command line option, init will be included, too. If a process is not in the report, it has dropped all capabilities. If the process has partial capabilities, it is further examined to see if it has an open-ended bounding set. If this is found to be true, a '+' symbol is added.
 
+The command name in the output may be followed by an asterisk mark (*). This mark denotes processes which run in child user namespaces (relative to the user namespace of pscap itself).
+
 .SH "SEE ALSO"
 .BR netcap (8),
 .BR filecap (8),


### PR DESCRIPTION
I was a bit surprised to see the following entry in the output of `pscap` on my machine:

```
5752  5754  qazer       chromium          sys_admin +
```

Then I realized that the browser was working in the child user namespace, not in the initial one, so its `CAP_SYS_ADMIN` should not compromise my system.

This PR is a suggestion to make things clearer and mark processes running in the child user namespaces with an asterisk, e.g.:

```
5752  5754  qazer       chromium *          sys_admin +
```

Another example - with rootless containers:

```
1     5658  qazer       podman pause *      full
10728 10961 qazer       podman *            full
1     10973 qazer       conmon *            full
10973 10984 qazer       sh *                chown, dac_override, fowner, fsetid, kill, setgid, setuid, setpcap, net_bind_service, net_raw, sys_chroot, mknod, audit_write, setfcap
10961 10993 qazer       slirp4netns *       full
```

Note:

1) technically, this PR breaks the backwards compatibility of `pscap` output. This is because the current version is below 1.0.0. Let me know if my assumption is false and the compatibility matters.
2) I avoided precise recursive checks for parent-child relation between namespaces with `ioctl()`, because I didn't see any case when we may dereference the namespace symlink in `/proc/PID/ns` for processes in user namespaces other than the current or child ones. Thus, the check just tries to dereference the link and checks that it does not point to the current NS.