### PR TITLE
src/cap-ng.c: fix build without threads

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -166,7 +166,9 @@ static void deinit(void)
 static void init_lib(void) __attribute__ ((constructor));
 static void init_lib(void)
 {
+#ifdef HAVE_PTHREAD_H
 	pthread_atfork(NULL, NULL, deinit);
+#endif
 }
 
 static void init(void)


### PR DESCRIPTION
Put pthread_atfork under #ifdef HAVE_PTHREAD_H block

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>