### PR TITLE
include missing endian.h header

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -33,6 +33,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <endian.h>
 #include <byteswap.h>
 #ifdef HAVE_PTHREAD_H
 #include <pthread.h>	// For pthread_atfork


### PR DESCRIPTION
musl needs this as otherwise both __BYTE_ORDER and __BIG_ENDIAN are undefined.