### PR TITLE
Avoid malloc/free in capng_apply

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -525,11 +525,12 @@ int capng_apply(capng_select_t set)
 
 	if (set & CAPNG_SELECT_BOUNDS) { 
 #ifdef PR_CAPBSET_DROP
-		void *s = capng_save_state();
+		struct cap_ng state;
+		memcpy(&state, &m, sizeof(state)); /* save state */
 		capng_get_caps_process();
 		if (capng_have_capability(CAPNG_EFFECTIVE, CAP_SETPCAP)) {
 			int i;
-			capng_restore_state(&s);
+			memcpy(&m, &state, sizeof(m)); /* restore state */
 			rc = 0;
 			for (i=0; i <= last_cap && rc == 0; i++)
 				if (capng_have_capability(CAPNG_BOUNDING_SET,
@@ -538,7 +539,7 @@ int capng_apply(capng_select_t set)
 			if (rc == 0)
 				m.state = CAPNG_APPLIED;
 		} else
-			capng_restore_state(&s);
+			memcpy(&m, &state, sizeof(m)); /* restore state */
 #else
 		rc = 0;
 #endif


### PR DESCRIPTION
POSIX does not mandate malloc() to be async-safe so calling malloc()
from child after fork may result in a deadlock. This resulted in
libvirtd deadlock with musl libc due to a call to capng_apply.

Fix this by storing the state on stack instead of using
capng_save_state().

Ref: https://gitlab.alpinelinux.org/alpine/aports/-/issues/11602