### PR TITLE
capng_apply: apply CAPNG_SELECT_CAPS before CAPNG_SELECT_BOUNDS

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -684,6 +684,13 @@ int capng_apply(capng_select_t set)
 	if (m.state < CAPNG_INIT)
 		return -1;
 
+	if (set & CAPNG_SELECT_CAPS) {
+		if (capset((cap_user_header_t)&m.hdr,
+				(cap_user_data_t)&m.data) == 0)
+			m.state = CAPNG_APPLIED;
+		else
+			return -5;
+	}
 	if (set & CAPNG_SELECT_BOUNDS) {
 #ifdef PR_CAPBSET_DROP
 		struct cap_ng state;
@@ -707,13 +714,6 @@ int capng_apply(capng_select_t set)
 			return -4;
 		}
 #endif
-	}
-	if (set & CAPNG_SELECT_CAPS) {
-		if (capset((cap_user_header_t)&m.hdr,
-				(cap_user_data_t)&m.data) == 0)
-			m.state = CAPNG_APPLIED;
-		else
-			return -5;
 	}
 	// Put ambient last so that inheritable and permitted are set
 	if (set & CAPNG_SELECT_AMBIENT) {


### PR DESCRIPTION
When using `capng_apply(CAPNG_SELECT_BOTH)`, libcap-ng before version 0.8.1 silently skipped applying bounding capabilities if `CAP_SETPCAP` was not given and continued to apply `CAPNG_SELECT_CAPS`.

libcap-ng 0.8.1 changed this behaviour in commits 6a24a9c5e2f3af1d56430417ee8c9a04ead38e6c and 2ab6a03b78cfa7620641c772d13ddbf3b405576b to return with an error when trying to set bounding capabilities without having `CAP_SETPCAP`. While this change generally is useful to be able to detect more errors, it means that `capng_apply(CAPNG_SELECT_BOTH)` now does not even apply `CAPNG_SELECT_CAPS` any more since the function returns early after failing to apply the bounding capabilities.

This change in behaviour might be surprising for legacy code that simply copied `capng_apply(CAPNG_SELECT_BOTH)` from the example code in the [README](https://github.com/stevegrubb/libcap-ng/blob/master/README.md#c-examples) and does not check the return value to see whether something went wrong. In this case, no capabilities are applied at all any more, which is a breaking change.

Applying `CAPNG_SELECT_CAPS` before `CAPNG_SELECT_BOUNDS` means that at least the `CAPNG_SELECT_CAPS` are applied, while still failing with an error of `-4` when `CAPNG_SELECT_BOTH` is used without `CAP_SETPCAP`.

I hope this strikes a balance between the need for better error checking and backwards compatibility with legacy code that does not perform any error checking on `capng_apply`, thus silently failing to apply any capabilities at all.