### PR TITLE
Make libdrop_ambient build conditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -121,6 +121,12 @@ AC_CHECK_DECLS([CAP_PERFMON], [], [], [[#include <linux/capability.h>]])
 AC_CHECK_DECLS([CAP_BPF], [], [], [[#include <linux/capability.h>]])
 AC_CHECK_DECLS([CAP_CHECKPOINT_RESTORE], [], [], [[#include <linux/capability.h>]])
 
+dnl only build libdrop_ambient if support for ambient capabilities was found (which is normal)
+if test x"${ac_cv_have_decl_PR_CAP_AMBIENT}" = x"no" ; then
+    AC_MSG_WARN("PR_CAP_AMBIENT not available - libdrop_ambient will not be built")
+fi
+AM_CONDITIONAL(BUILD_LIBDROP_AMBIENT, test x"${ac_cv_have_decl_PR_CAP_AMBIENT}" = x"yes")
+
 AC_CHECK_PROG(swig_found, swig, yes, no)
 if test x"${swig_found}" = x"no" ; then
 	AC_MSG_WARN("Swig not found - python bindings will not be made")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,10 @@ CLEANFILES = $(BUILT_SOURCES)
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 AM_CFLAGS = -fPIC -DPIC -W -Wall -Wshadow -Wformat -Wundef -D_GNU_SOURCE
 AM_CPPFLAGS = -I. -I${top_srcdir}
-lib_LTLIBRARIES = libcap-ng.la libdrop_ambient.la
+lib_LTLIBRARIES = libcap-ng.la
+if BUILD_LIBDROP_AMBIENT
+  lib_LTLIBRARIES += libdrop_ambient.la
+endif
 include_HEADERS = cap-ng.h
 noinst_HEADERS = captab.h
 libcap_ng_la_SOURCES = cap-ng.c lookup_table.c


### PR DESCRIPTION
It is possible (though nowadays rare) for a system to lack support
for ambient caps. For that case, libdrop_ambient is irrelevant and
breaks the build, so don't try to build it.

This change addresses issue #24 