### PR TITLE
bindings/python: Allow hardcoded path to capability.h to be overridden

### DIFF
--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -38,7 +38,7 @@ nodist__capng_la_SOURCES  = capng_wrap.c
 capng.py capng_wrap.c: ${srcdir}/../src/capng_swig.i caps.h capng.h
 	swig -o capng_wrap.c ${SWIG_FLAGS} ${SWIG_INCLUDES} ${srcdir}/../src/capng_swig.i 
 caps.h:
-	cat /usr/include/linux/capability.h | grep '^#define CAP'  | grep -v '[()]' > caps.h
+	cat $(CAPABILITY_HEADER) | grep '^#define CAP'  | grep -v '[()]' > caps.h
 capng.h:
 	cat ${top_srcdir}/src/cap-ng.h | grep -v '_state' > capng.h
 

--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -41,7 +41,7 @@ nodist__capng_la_SOURCES  = capng_wrap.c
 capng.py capng_wrap.c: ${srcdir}/../src/capng_swig.i caps.h capng.h
 	swig -o capng_wrap.c ${SWIG_FLAGS} ${SWIG_INCLUDES} ${srcdir}/../src/capng_swig.i
 caps.h:
-	cat /usr/include/linux/capability.h | grep '^#define CAP'  | grep -v '[()]' > caps.h
+	cat $(CAPABILITY_HEADER) | grep '^#define CAP'  | grep -v '[()]' > caps.h
 capng.h:
 	cat ${top_srcdir}/src/cap-ng.h | grep -v '_state' > capng.h
 

--- a/configure.ac
+++ b/configure.ac
@@ -63,6 +63,12 @@ AC_CHECK_HEADERS(sys/vfs.h, [
 	AC_CHECK_HEADERS(linux/magic.h, [] [AC_MSG_WARN(linux/magic.h is required in order to verify procfs.)])
 	], [AC_MSG_WARN(sys/vfs.h is required in order to verify procfs.)])
 
+AC_ARG_WITH([capability_header],
+        [AS_HELP_STRING([--with-capability_header=path : path to cpapbility.h])],
+        [CAPABILITY_HEADER=$withval],
+        [CAPABILITY_HEADER=/usr/include/linux/capability.h])
+AC_SUBST(CAPABILITY_HEADER)
+
 ALLWARNS=""
 ALLDEBUG="-g"
 OPT="-O"


### PR DESCRIPTION
Currently the path to capability.h is hardcoded. When cross compiling
the host capabiity.h may be different to the target copy, leading
to different options being encoded in the python bindings than
expected. This causes a reproducibility issue amongst other potential
problems.

Add a configure option to optionally specify the right path to the
correct header as its probably safer/more reliable than trying to
query the compiler to get the header path.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>