### PR TITLE
Export capng_init() to be called when linked statically

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 0.8.3
 - Fix parameters to capng_updatev python bindings to be signed
 - Detect capability options at runtime to make containerization easier (ntkme)
+- Initialize the library when linked statically.
 
 0.8.2
 - In capng_apply, if we blew up in bounding set, allow setting capabilities

--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -214,6 +214,12 @@ static inline int test_cap(unsigned int cap)
 static void init_lib(void) __attribute__ ((constructor));
 static void init_lib(void)
 {
+       // This is so dynamic libraries don't re-init
+       static unsigned int run_once = 0;
+       if (run_once)
+               return;
+       run_once = 1;
+
 #ifdef HAVE_PTHREAD_H
 	pthread_atfork(NULL, NULL, deinit);
 #endif
@@ -288,6 +294,9 @@ fail:
 
 static void init(void)
 {
+	// This is for so static libs get initialized
+	init_lib();
+
 	if (m.state != CAPNG_NEW)
 		return;
 


### PR DESCRIPTION
The attribute constructor mechanism only works for shared library.

When _libcap_ng_ is linked as static library, we need to call the `init_lib()` function manually. This patch makes the function external, renames it to `capng_init()` (to be consistent with other functions) and adds a manual page for documentation.