### PR TITLE
Change manual section and add whatis entry.

### DIFF
--- a/docs/libdrop_ambient.7
+++ b/docs/libdrop_ambient.7
@@ -1,6 +1,6 @@
-.TH "LIBDROP_AMBIENT" "3" "Nov 2020" "Red Hat" "Libcap-ng API"
+.TH "LIBDROP_AMBIENT" "7" "Nov 2020" "Red Hat" "Libcap-ng API"
 .SH NAME
-libdrop_ambient
+libdrop_ambient \- force application started with ambient capabilities to drop them
 
 .SH "DESCRIPTION
 


### PR DESCRIPTION
This was installed in section 7, and the header specified section 3.
Since this isn't a library call I'm assuming section 7 is correct.