### PR TITLE
Fix typo in configure.ac for the linux/magic.h header check.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ AC_CHECK_HEADERS(pthread.h,
 	[AC_SEARCH_LIBS(pthread_atfork, pthread)],
 	[AC_MSG_WARN(pthread.h not found, disabling pthread_atfork.)])
 AC_CHECK_HEADERS(sys/vfs.h, [
-	AC_CHECK_HEADERS(linux/magic.h, [] [AC_MSG_WARN(linux/magic.h is required in order to verify procfs.)])
+	AC_CHECK_HEADERS(linux/magic.h, [], [AC_MSG_WARN(linux/magic.h is required in order to verify procfs.)])
 	], [AC_MSG_WARN(sys/vfs.h is required in order to verify procfs.)])
 
 AC_ARG_WITH([capability_header],


### PR DESCRIPTION
I noticed a missing comma here.  Without the comma, you get the warning message about requiring linux/magic.h regardless of whether or not the configure script found it.

Signed-off-by: David Cantrell <dcantrell@redhat.com>