### PR TITLE
Updated documentation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ SUBDIRS = src utils m4 docs
 if HAVE_SWIG
 SUBDIRS += bindings
 endif
-EXTRA_DIST = ChangeLog AUTHORS README INSTALL COPYING COPYING.LIB \
+EXTRA_DIST = ChangeLog AUTHORS README.md INSTALL COPYING COPYING.LIB \
 	libcap-ng.spec autogen.sh 
 
 CONFIG_CLEAN_FILES = debug*.list config/*

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,7 @@ SUBDIRS = src utils m4 docs
 if HAVE_SWIG
 SUBDIRS += bindings
 endif
-EXTRA_DIST = ChangeLog AUTHORS NEWS README INSTALL COPYING COPYING.LIB \
+EXTRA_DIST = ChangeLog AUTHORS README INSTALL COPYING COPYING.LIB \
 	libcap-ng.spec autogen.sh 
 
 CONFIG_CLEAN_FILES = debug*.list config/*

--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-Report any bugs in this package to:
-https://github.com/stevegrubb/libcap-ng/issue
-
-Additional information can be found at:
-http://people.redhat.com/sgrubb/libcap-ng

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 libcap-ng
 =========
 
-The libcap-ng library should make programming with posix capabilities
+The libcap-ng library should make programming with POSIX capabilities
 easier. The library has some utilities to help you analyse a system
 for apps that may have too much privileges.
 

--- a/README.md
+++ b/README.md
@@ -38,35 +38,45 @@ interested in: drop all capabilities, keep one capability, keep several
 capabilities, check if you have any capabilities at all, check for certain
 capabilities, and retain capabilities across a uid change.
 
-```
 1) Drop all capabilities
-     capng_clear(CAPNG_SELECT_BOTH);
-     capng_apply(CAPNG_SELECT_BOTH);
+   ```c
+   capng_clear(CAPNG_SELECT_BOTH);
+   capng_apply(CAPNG_SELECT_BOTH);
+   ```
 
 2) Keep one capability
-     capng_clear(CAPNG_SELECT_BOTH);
-     capng_update(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_CHOWN);
-     capng_apply(CAPNG_SELECT_BOTH);
+   ```c
+   capng_clear(CAPNG_SELECT_BOTH);
+   capng_update(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_CHOWN);
+   capng_apply(CAPNG_SELECT_BOTH);
+   ```
 
 3) Keep several capabilities
-     capng_clear(CAPNG_SELECT_BOTH);
-     capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_SETUID, CAP_SETGID, -1);
-     capng_apply(CAPNG_SELECT_BOTH);
+   ```c
+   capng_clear(CAPNG_SELECT_BOTH);
+   capng_updatev(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_SETUID, CAP_SETGID, -1);
+   capng_apply(CAPNG_SELECT_BOTH);
+   ```
 
 4) Check if you have any capabilities
-     if (capng_have_capabilities(CAPNG_SELECT_CAPS) > CAPNG_NONE)
-         do_something();
+   ```c
+   if (capng_have_capabilities(CAPNG_SELECT_CAPS) > CAPNG_NONE)
+       do_something();
+   ```
 
 5) Check for a specific capability
-     if (capng_have_capability(CAPNG_EFFECTIVE, CAP_CHOWN))
-         do_something();
+   ```c
+   if (capng_have_capability(CAPNG_EFFECTIVE, CAP_CHOWN))
+       do_something();
+   ```
 
 6) Retain capabilities across a uid change
-     capng_clear(CAPNG_SELECT_BOTH);
-     capng_update(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_CHOWN);
-     if (capng_change_id(99, 99, CAPNG_DROP_SUPP_GRP | CAPNG_CLEAR_BOUNDING))
-         error();
-```
+   ```c
+   capng_clear(CAPNG_SELECT_BOTH);
+   capng_update(CAPNG_ADD, CAPNG_EFFECTIVE|CAPNG_PERMITTED, CAP_CHOWN);
+   if (capng_change_id(99, 99, CAPNG_DROP_SUPP_GRP | CAPNG_CLEAR_BOUNDING))
+       error();
+   ```
 
 Now, isn't that a lot simpler? Note that the last example takes about 60 lines
 of code using the older capabilities library. As of the 0.6 release, there is
@@ -79,35 +89,45 @@ Python
 ------
 Libcap-ng 0.6 and later has python bindings. (Only python3 is supported from 0.8.4 onward.) You simply add 'import capng' in your script.  Here are the same examples as above in python:
 
-```
 1) Drop all capabilities
-     capng.capng_clear(capng.CAPNG_SELECT_BOTH)
-     capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```python
+   capng.capng_clear(capng.CAPNG_SELECT_BOTH)
+   capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```
 
 2) Keep one capability
-     capng.capng_clear(capng.CAPNG_SELECT_BOTH)
-     capng.capng_update(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_CHOWN)
-     capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```python
+   capng.capng_clear(capng.CAPNG_SELECT_BOTH)
+   capng.capng_update(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_CHOWN)
+   capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```
 
 3) Keep several capabilities
-     capng.capng_clear(capng.CAPNG_SELECT_BOTH)
-     capng.capng_updatev(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_SETUID, capng.CAP_SETGID, -1)
-     capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```python
+   capng.capng_clear(capng.CAPNG_SELECT_BOTH)
+   capng.capng_updatev(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_SETUID, capng.CAP_SETGID, -1)
+   capng.capng_apply(capng.CAPNG_SELECT_BOTH)
+   ```
 
 4) Check if you have any capabilities
-     if capng.capng_have_capabilities(capng.CAPNG_SELECT_CAPS) > capng.CAPNG_NONE:
-         do_something()
+   ```python
+   if capng.capng_have_capabilities(capng.CAPNG_SELECT_CAPS) > capng.CAPNG_NONE:
+       do_something()
+   ```
 
 5) Check for a specific capability
-     if capng.capng_have_capability(capng.CAPNG_EFFECTIVE, capng.CAP_CHOWN):
-         do_something()
+   ```python
+   if capng.capng_have_capability(capng.CAPNG_EFFECTIVE, capng.CAP_CHOWN):
+       do_something()
+   ```
 
 6) Retain capabilities across a uid change
-     capng.capng_clear(capng.CAPNG_SELECT_BOTH)
-     capng.capng_update(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_CHOWN)
-     if capng.capng_change_id(99, 99, capng.CAPNG_DROP_SUPP_GRP | capng.CAPNG_CLEAR_BOUNDING) < 0:
-         error()
-```
+   ```python
+   capng.capng_clear(capng.CAPNG_SELECT_BOTH)
+   capng.capng_update(capng.CAPNG_ADD, capng.CAPNG_EFFECTIVE|capng.CAPNG_PERMITTED, capng.CAP_CHOWN)
+   if capng.capng_change_id(99, 99, capng.CAPNG_DROP_SUPP_GRP | capng.CAPNG_CLEAR_BOUNDING) < 0:
+       error()
+   ```
 
 The one caveat is that printing capabilities from python does not work. But
 you can still manipulate capabilities, though.

--- a/docs/capng_apply.3
+++ b/docs/capng_apply.3
@@ -8,7 +8,7 @@ int capng_apply(capng_select_t set);
 
 .SH "DESCRIPTION"
 
-capng_apply will transfer the specified internal posix capabilities settings to the kernel. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if transferring both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if applying all is desired.
+capng_apply will transfer the specified internal POSIX capabilities settings to the kernel. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if transferring both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if applying all is desired.
 
 .SH "RETURN VALUE"
 

--- a/docs/capng_clear.3
+++ b/docs/capng_clear.3
@@ -8,7 +8,7 @@ void capng_clear(capng_select_t set);
 
 .SH "DESCRIPTION"
 
-capng_clear sets to 0 all bits in the selected posix capabilities set. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if clearing both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if clearing all is desired.
+capng_clear sets to 0 all bits in the selected POSIX capabilities set. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if clearing both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if clearing all is desired.
 
 .SH "RETURN VALUE"
 

--- a/docs/capng_fill.3
+++ b/docs/capng_fill.3
@@ -8,7 +8,7 @@ void capng_fill(capng_select_t set);
 
 .SH "DESCRIPTION"
 
-capng_fill sets all bits to a 1 in the selected posix capabilities set. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if filling both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if clearing all is desired..
+capng_fill sets all bits to a 1 in the selected POSIX capabilities set. The options are CAPNG_SELECT_CAPS for the traditional capabilities, CAPNG_SELECT_BOUNDS for the bounding set, CAPNG_SELECT_BOTH if filling both is desired, CAPNG_SELECT_AMBIENT if only operating on the ambient capabilities, or CAPNG_SELECT_ALL if clearing all is desired..
 
 .SH "RETURN VALUE"
 

--- a/docs/capng_update.3
+++ b/docs/capng_update.3
@@ -8,7 +8,7 @@ int capng_update(capng_act_t action, capng_type_t type,unsigned int capability);
 
 .SH "DESCRIPTION"
 
-capng_update will update the internal posix capabilities settings based on the options passed to it. The action should be either CAPNG_DROP to set the capability bit to 0, or CAPNG_ADD to set the capability bit to 1. The operation is performed on the capability set specified in the type parameter. The values are: CAPNG_EFFECTIVE, CAPNG_PERMITTED, CAPNG_INHERITABLE, CAPNG_BOUNDING_SET, or CAPNG_AMBIENT. The values may be or'ed together to perform the same operation on multiple sets. The last parameter, capability, is the capability define as given in linux/capability.h.
+capng_update will update the internal POSIX capabilities settings based on the options passed to it. The action should be either CAPNG_DROP to set the capability bit to 0, or CAPNG_ADD to set the capability bit to 1. The operation is performed on the capability set specified in the type parameter. The values are: CAPNG_EFFECTIVE, CAPNG_PERMITTED, CAPNG_INHERITABLE, CAPNG_BOUNDING_SET, or CAPNG_AMBIENT. The values may be or'ed together to perform the same operation on multiple sets. The last parameter, capability, is the capability define as given in linux/capability.h.
 
 .SH "RETURN VALUE"
 

--- a/docs/capng_updatev.3
+++ b/docs/capng_updatev.3
@@ -9,7 +9,7 @@ int capng_updatev(capng_act_t action, capng_type_t type,
 
 .SH "DESCRIPTION"
 
-capng_updatev will update the internal posix capabilities settings based on the options passed to it. The action should be either CAPNG_DROP to set the capability bit to 0, or CAPNG_ADD to set the capability bit to 1. The operation is performed on the capability set specified in the type parameter. The values are: CAPNG_EFFECTIVE, CAPNG_PERMITTED, CAPNG_INHERITABLE, CAPNG_BOUNDING_SET, or CAPNG_AMBIENT. The values may be or'ed together to perform the same operation on multiple sets. The last parameter, capability, is the capability define as given in linux/capability.h.
+capng_updatev will update the internal POSIX capabilities settings based on the options passed to it. The action should be either CAPNG_DROP to set the capability bit to 0, or CAPNG_ADD to set the capability bit to 1. The operation is performed on the capability set specified in the type parameter. The values are: CAPNG_EFFECTIVE, CAPNG_PERMITTED, CAPNG_INHERITABLE, CAPNG_BOUNDING_SET, or CAPNG_AMBIENT. The values may be or'ed together to perform the same operation on multiple sets. The last parameter, capability, is the capability define as given in linux/capability.h.
 
 This function differs from capng_update in that you may pass a list of capabilities. This list must be terminated with a -1 value.
 

--- a/libcap-ng.spec
+++ b/libcap-ng.spec
@@ -1,4 +1,4 @@
-Summary: An alternate posix capabilities library
+Summary: An alternate POSIX capabilities library
 Name: libcap-ng
 Version: 0.8.4
 Release: 1%{?dist}
@@ -11,7 +11,7 @@ BuildRequires: kernel-headers >= 2.6.11
 BuildRequires: libattr-devel
 
 %description
-Libcap-ng is a library that makes using posix capabilities easier
+Libcap-ng is a library that makes using POSIX capabilities easier
 
 %package devel
 Summary: Header files for libcap-ng library
@@ -43,7 +43,7 @@ Group: Development/Libraries
 
 %description utils
 The libcap-ng-utils package contains applications to analyze the
-posix capabilities of all the program running on a system. It also
+POSIX capabilities of all the program running on a system. It also
 lets you set the file system based capabilities.
 
 %prep

--- a/src/libcap-ng.pc.in
+++ b/src/libcap-ng.pc.in
@@ -4,7 +4,7 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: libcap-ng
-Description: An alternate posix capabilities library.
+Description: An alternate POSIX capabilities library.
 Version: @VERSION@
 Libs: -L${libdir} -lcap-ng
 Cflags: -I${includedir}


### PR DESCRIPTION
- POSIX is written in uppercase
- Split examples into a proper markdown list and separate code-blocks
- Drop empty NEWS file, we're using ChangeLog
- Remove README, ship README.md instead