### PR TITLE
Fix calls to undeclared functions

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -49,6 +49,9 @@
 #include <sys/vfs.h>
 #include <linux/magic.h>
 #endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
 
 # define hidden __attribute__ ((visibility ("hidden")))
 unsigned int last_cap hidden = 0;


### PR DESCRIPTION
Discovered with using Zig to build libcap-ng v0.8.4.

```
/home/ross/.cache/zig/p/1220a06039f203b43526577b3c6fdfebd78a37ec3535e01adee3dc8334a5a4a27f85/src/cap-ng.c:1027:8: error: call to undeclared function 'setresgid'; ISO C99 and later do not support implicit function declarations
  rc = setresgid(gid, gid, gid);
       ^
/home/ross/.cache/zig/p/1220a06039f203b43526577b3c6fdfebd78a37ec3535e01adee3dc8334a5a4a27f85/src/cap-ng.c:1062:8: error: call to undeclared function 'setresuid'; ISO C99 and later do not support implicit function declarations
  rc = setresuid(uid, uid, uid);
       ^
```