### PR TITLE
Fix the syntax error in cap-ng.c

### DIFF
--- a/src/cap-ng.c
+++ b/src/cap-ng.c
@@ -445,7 +445,7 @@ static int get_bounding_set(void)
 #ifdef HAVE_SYSCALL_H
 		(int)syscall(__NR_gettid));
 #else
-		(int)getpid();
+		(int)getpid());
 #endif
 	f = fopen(buf, "re");
 	if (f) {
@@ -490,7 +490,7 @@ static int get_ambient_set(void)
 #ifdef HAVE_SYSCALL_H
 		(int)syscall(__NR_gettid));
 #else
-		(int)getpid();
+		(int)getpid());
 #endif
 	f = fopen(buf, "re");
 	if (f) {


### PR DESCRIPTION
```
cap-ng.c: In function 'get_bounding_set':
cap-ng.c:447:16: error: expected ')' before ';' token
  447 |   (int)getpid();
      |                ^
      |                )
cap-ng.c:477:11: error: expected ';' before '}' token
  477 |  return 0;
      |           ^
      |           ;
  478 | }
      | ~          

cap-ng.c: In function 'get_ambient_set':
cap-ng.c:492:16: error: expected ')' before ';' token
  492 |   (int)getpid();
      |                ^
      |                )
cap-ng.c:522:11: error: expected ';' before '}' token
  522 |  return 0;
      |           ^
      |           ;
  523 | }
      | ~ 
```