### PR TITLE
Fix python path when invoking py-compile

### DIFF
--- a/bindings/python3/Makefile.am
+++ b/bindings/python3/Makefile.am
@@ -27,7 +27,6 @@ AM_CPPFLAGS = -I. -I$(top_builddir) $(PYTHON3_INCLUDES)
 LIBS = ${top_builddir}/src/libcap-ng.la
 SWIG_FLAGS = -python
 SWIG_INCLUDES = ${AM_CPPFLAGS}
-PYTHON = $(PYTHON3)
 pyexec_PYTHON = capng.py
 pyexec_LTLIBRARIES = _capng.la
 pyexec_SOLIBRARIES = _capng.so


### PR DESCRIPTION
48eebb2 replaced custom PYTHON3 variable with PYTHON by using standard AM_PATH_PYTHON macro. Makefile however still referred to old one. There's no need to set PYTHON explicitly anymore so drop it.

Fixes #53