### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/src/libcap-ng.pc.in
+++ b/src/libcap-ng.pc.in
@@ -8,4 +8,5 @@ Description: An alternate POSIX capabilities library.
 Version: @VERSION@
 Libs: -L${libdir} -lcap-ng
 Cflags: -I${includedir}
+License: LGPL-2.1-or-later
 


### PR DESCRIPTION
The pkg-config file has License variable that allows you to set the license for the software. 
This sets LGPL-2.1-or-later to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116