### PR TITLE
cap-audit: fix out-of-source builds

### DIFF
--- a/utils/cap-audit/Makefile.am
+++ b/utils/cap-audit/Makefile.am
@@ -20,7 +20,7 @@
 SUBDIRS = test
 DIST_SUBDIRS = test
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/src ${LIBBPF_CFLAGS} ${LIBAUDIT_CFLAGS}
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/src -I$(top_builddir)/utils/cap-audit ${LIBBPF_CFLAGS} ${LIBAUDIT_CFLAGS}
 AM_CFLAGS = -W -Wall -Wshadow ${WFLAGS} -Wundef -D_GNU_SOURCE
 
 if BUILD_CAP_AUDIT


### PR DESCRIPTION
With an out-of-source build, bpftool puts the generated vmlinux.h in the build directory, not the source directory, so we need to tell Clang where to find it.