### PR TITLE
configure.ac: a tab is not okay on all systems, eg Ubuntu 20

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,8 +153,7 @@ AC_CHECK_HEADERS(sys/xattr.h, [], [
 	])
 AC_CHECK_HEADERS(linux/securebits.h, [], [])
 AC_CHECK_HEADERS(bluetooth/bluetooth.h bluetooth/hci.h, [], [])
-AC_CHECK_HEADERS(linux/inet_diag.h linux/netlink.h linux/sock_diag.h
-	linux/vm_sockets.h, [], [])
+AC_CHECK_HEADERS(linux/inet_diag.h linux/netlink.h linux/sock_diag.h linux/vm_sockets.h, [], [])
 AC_CHECK_HEADERS(linux/vm_sockets_diag.h, [], [])
 AC_CHECK_HEADERS(pthread.h,
 	[AC_SEARCH_LIBS(pthread_atfork, pthread)],


### PR DESCRIPTION
With Fedora 43 there is no problem
See https://github.com/Freetz-NG/freetz-ng/blob/master/make/libs/libcap-ng/patches/100-fix_netcap_hdr_syntax.patch