### PR TITLE
Fix error checking of vm_sockets with kernel before 6.16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,13 @@ AC_CHECK_HEADERS(sys/xattr.h, [], [
 	])
 AC_CHECK_HEADERS(linux/securebits.h, [], [])
 AC_CHECK_HEADERS(bluetooth/bluetooth.h bluetooth/hci.h, [], [])
-AC_CHECK_HEADERS(linux/inet_diag.h linux/netlink.h linux/sock_diag.h linux/vm_sockets.h, [], [])
+AC_CHECK_HEADERS(linux/inet_diag.h linux/netlink.h linux/sock_diag.h, [], [])
+AC_CHECK_HEADERS(sys/socket.h, [], [])
+AC_CHECK_HEADERS(linux/vm_sockets.h, [], [], [AC_INCLUDES_DEFAULT
+		#ifdef HAVE_SYS_SOCKET_H
+		#include <sys/socket.h>
+		#endif
+		])
 AC_CHECK_HEADERS(linux/vm_sockets_diag.h, [], [])
 AC_CHECK_HEADERS(pthread.h,
 	[AC_SEARCH_LIBS(pthread_atfork, pthread)],


### PR DESCRIPTION
The header file linux/vm_sockets.h doesn't include sys/socket.h before kernel-6.16. Include sys/socket.h first at checking for vm_sockets.h in configure.ac.

configure:15387: checking for linux/vm_sockets.h
configure:15387: gcc -c -O2 -flto=auto -ffat-lto-objects -g -grecord-gcc-switches -pipe -fstack-protector-strong  -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/generic-hardened-cc1 -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection  conftest.c >&5 In file included from conftest.c:57:
/usr/include/linux/vm_sockets.h:182:39: error: invalid application of 'sizeof' to incomplete type 'struct sockaddr'
  182 |         unsigned char svm_zero[sizeof(struct sockaddr) -
      |                                       ^~~~~~
/usr/include/linux/vm_sockets.h:183:39: error: 'sa_family_t' undeclared here (not in a function)
  183 |                                sizeof(sa_family_t) -
      |                                       ^~~~~~~~~~~
configure:15387: $? = 1